### PR TITLE
Synapse RBAC on ADLS

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,25 @@
 output "synapse_workspace_id" {
-  value = azurerm_synapse_workspace.main.id
+  description = "Synapse workspace resource ID."
+  value       = azurerm_synapse_workspace.main.id
+}
+
+output "synapse_workspace_mi_id" {
+  description = "Principal ID of Synapse workspace's managed identity."
+  value       = azurerm_synapse_workspace.main.identity[0].principal_id
 }
 
 output "storage_account_id" {
-  value = azurerm_storage_account.main.id
+  description = "Data lake storage account resource ID."
+  value       = azurerm_storage_account.main.id
+}
+
+output "storage_account_name" {
+  description = "Data lake storage account resource name."
+  value       = azurerm_storage_account.main.name
+}
+
+output "storage_account_connection_string_primary" {
+  description = "Data lake storage account primary connection string."
+  sensitive   = true
+  value       = azurerm_storage_account.main.primary_connection_string
 }

--- a/synapse.tf
+++ b/synapse.tf
@@ -68,3 +68,9 @@ resource "azurerm_synapse_role_assignment" "roles" {
   role_name            = each.value.role_name
   principal_id         = each.value.principal_id
 }
+
+resource "azurerm_role_assignment" "synapse_adls" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_synapse_workspace.main.identity[0].principal_id
+}


### PR DESCRIPTION
This PR includes:
* addition of role assignment (`Storage Blob Data Contributor`) on ADLS storage account to Synapse's managed identity
* additional module outputs
  * Synapse workspace managed identity ID
  * ADLS storage account name
  * ADLS storage account primary connection string (sensitive) 